### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# rwd-navbar-selector
+
+自適應導覽列，並偵測位置反應區塊漸層。


### PR DESCRIPTION
# Rwd Navbar Selector

自適應導覽列，並偵測位置反應區塊漸層。

這版的CSS有點問題`id="sidebar"`的`flex`跑到上面去，像是`align-items: center `沒有起作用，但對比文件前後好幾次還是沒找到問題，基本認定使用sass的時候縮排跑掉，但一直找不到地方。